### PR TITLE
fix: misspelled

### DIFF
--- a/subbrute_device.h
+++ b/subbrute_device.h
@@ -58,7 +58,7 @@ typedef struct {
     uint8_t bit_index;
 } SubBruteDevice;
 
-SubBruteDevice* subbrute_device_alloc(const SubGhzDevice* radio_device;);
+SubBruteDevice* subbrute_device_alloc(const SubGhzDevice* radio_device);
 void subbrute_device_free(SubBruteDevice* instance);
 
 bool subbrute_device_save_file(SubBruteDevice* instance, const char* key_name);


### PR DESCRIPTION
Actually misspelled line: [61](https://github.com/DarkFlippers/flipperzero-subbrute/blob/a2d198782d456f0be3b1da31c28164a5a7f93a7d/subbrute_device.h#L61C71-L61C71)