### PR TITLE
Add workflow to automatically close stale issues and PRs

### DIFF
--- a/.github/workflows/build-with-firmware.yml
+++ b/.github/workflows/build-with-firmware.yml
@@ -232,8 +232,7 @@ jobs:
           $json = (gh api -H $mime -H $api /repos/${{ github.REPOSITORY }}/releases) | ConvertFrom-Json
           $tagExists = ($json.GetEnumerator() | Where-Object { $_.tag_name -eq 'v${{ env.RELEASE_VERSION }}' }) -ne $null
           if ( $tagExists -eq $false ) {
-            gh api --method POST -H $mime -H $api /repos/${{ github.REPOSITORY }}/releases -f tag_name='v${{ env.RELEASE_VERSION }}' -f target_commitish='${{ env.SHA }}' -f name='v${{ env.RELEASE_VERSION }}' -F draft=true -F prerelease=false -F generate_release_notes=false  
-            gh api --method POST -H $mime -H $api /repos/${{ github.REPOSITORY }}/releases/generate-notes -f tag_name='v${{ env.RELEASE_VERSION }}' -f target_commitish='${{ env.SHA }}' -f previous_tag_name='${{ env.PREV_TAG }}'
+            gh api --method POST -H $mime -H $api /repos/${{ github.REPOSITORY }}/releases -f tag_name='v${{ env.RELEASE_VERSION }}' -f target_commitish='${{ env.SHA }}' -f name='v${{ env.RELEASE_VERSION }}' -F draft=false -F prerelease=false -F generate_release_notes=true
           }          
           gh release upload 'v${{ env.RELEASE_VERSION }}' '${{ env.ZIP_NAME }}#${{ env.ZIP_TAG }}' '${{ env.TGZ_NAME }}#${{ env.TGZ_TAG }}' --clobber -R ${{ env.REPO_SELF }}
           gh release edit 'v${{ env.RELEASE_VERSION }}' --draft=false -R ${{ env.REPO_SELF }}


### PR DESCRIPTION
Introduced a new GitHub workflow that automatically flags and closes stale issues and PRs. This GitHub Action runs on a schedule (every hour) and works by marking inactive pull requests as stale after 14 days of inactivity, and subsequently closing them if there's still no activity after an additional 14 days. The PRs to be exempted from this workflow are also specified.