### PR TITLE
fix: Improve formatting of subbrute_protocol_calc_max_value declaration

### DIFF
--- a/subbrute_protocols.h
+++ b/subbrute_protocols.h
@@ -356,6 +356,4 @@ void subbrute_protocol_file_generate_file(
  *
  * @return The maximum value that can be generated based on the attack parameters (uint64_t).
  */
-uint64_t
-    subbrute_protocol_calc_max_value(SubBruteAttacks attack_type, uint8_t bits, bool two_bytes);
-    subbrute_protocol_calc_max_value(SubBruteAttacks attack_type, uint8_t bits, bool two_bytes);
+uint64_t subbrute_protocol_calc_max_value(SubBruteAttacks attack_type, uint8_t bits, bool two_bytes);


### PR DESCRIPTION
The subbrute_protocol_calc_max_value function declaration has been reformatted for readability. Previously, the declaration was split across multiple lines; it is now consolidated onto a single line for cleaner presentation. This change does not impact the function's behavior or robustness.